### PR TITLE
minor fix to avoid startup error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ by Andy Clymer, [www.andyclymer.com](http://www.andyclymer.com)
 
 updated for RF4.4 by Connor Davenport [www.connordavenport.com](http://www.connordavenport.com)
 
-![Blue Zone Editor Icon](/resources/icon.png?raw=true)
+![Blue Zone Editor Icon](source/resources/icon.png?raw=true)
 
 Download it here, or find it in the Mechanic 2 extension
 

--- a/info.yaml
+++ b/info.yaml
@@ -3,7 +3,7 @@ developer: Andy Clymer
 developerURL: http://www.andyclymer.com/
 launchAtStartUp: true
 mainScript: Blues.py
-version: '1.4'
+version: '1.4.1'
 addToMenu: []
 html: true
 requiresVersionMajor: '4'

--- a/source/lib/Blues.py
+++ b/source/lib/Blues.py
@@ -26,7 +26,7 @@ BLUESCOLOR = (c.redComponent(), c.greenComponent(), c.blueComponent(), c.alphaCo
 c = getDefaultColor("glyphViewOtherBluesColor")
 OTHERBLUESCOLOR = (c.redComponent(), c.greenComponent(), c.blueComponent(), c.alphaComponent())
 
-VIEWWIDTH = getDefault("glyphViewArtBoardHorizontalBorder") * 2
+VIEWWIDTH = getDefault("glyphViewHorizontalPadding", 3000) * 2
 
 KEY = "com.andyclymer.blueZoneEditor"
     


### PR DESCRIPTION
I saw a RF startup error, this fixes it.
```
23/01/2025 14:52:36 >   OUTPUT > ROBOFONT >> Installing 'Blue Zone Editor' report:
23/01/2025 14:52:36 >   OUTPUT > ROBOFONT >> Traceback (most recent call last):
                                          >>       File "Blues.py", line 29, in <module>
                                          >>     TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```

(`glyphViewArtBoardHorizontalBorder` is now `glyphViewHorizontalPadding `)
